### PR TITLE
Removing resource limits from pod containers

### DIFF
--- a/microservices/client/kustomize/base/client-deployment.yaml
+++ b/microservices/client/kustomize/base/client-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         envFrom:
           - configMapRef:
               name: client-config
-        resources:
-          limits:
-            memory: "512Mi"
-            cpu: "1000m"
+        # resources:
+        #   limits:
+        #     memory: "512Mi"
+        #     cpu: "1000m"

--- a/microservices/server/kustomize/base/server-deployment.yaml
+++ b/microservices/server/kustomize/base/server-deployment.yaml
@@ -15,10 +15,10 @@ spec:
       containers:
       - name: server
         image: fcabrera01/open-ims-server
-        resources:
-          limits:
-            memory: "512Mi"
-            cpu: "1000m"
+        # resources:
+        #   limits:
+        #     memory: "512Mi"
+        #     cpu: "1000m"
         ports:
         - containerPort: 3000
         envFrom:


### PR DESCRIPTION
Digital Ocean was complaining about not having enough cpu for these processes, wondering if the limits I set are too high. Our nodes are only 1GB useable ram and 50GB ssd.