### PR TITLE
updating SQL DROP commands to respect references

### DIFF
--- a/common/utils/migration-job/migrations/sqls/20230814020356-db-initialization-down.sql
+++ b/common/utils/migration-job/migrations/sqls/20230814020356-db-initialization-down.sql
@@ -4,19 +4,11 @@ DROP TABLE IF EXISTS public.customer_addresses;
 
 DROP TABLE IF EXISTS public.vendor_addresses;
 
-DROP TYPE IF EXISTS public.address_type;
-
 DROP TABLE IF EXISTS public.vendor_and_customer;
 
 DROP TABLE IF EXISTS public.invoice_orders;
 
-DROP TYPE IF EXISTS public.sales_order_delivery;
-
 DROP TABLE IF EXISTS public.purchase_orders;
-
-DROP TYPE IF EXISTS public.purchase_order_delivery;
-
-DROP TYPE IF EXISTS public.order_payment;
 
 DROP TABLE IF EXISTS public.products_table;
 
@@ -26,8 +18,16 @@ DROP TABLE IF EXISTS public.vendor_table;
 
 DROP TABLE IF EXISTS public.user_table;
 
+DROP TABLE IF EXISTS public.employee_table;
+
+DROP TYPE IF EXISTS public.address_type;
+
+DROP TYPE IF EXISTS public.sales_order_delivery;
+
+DROP TYPE IF EXISTS public.purchase_order_delivery;
+
+DROP TYPE IF EXISTS public.order_payment;
+
 DROP TYPE IF EXISTS public.user_permission;
 
 DROP TYPE IF EXISTS public.order_status;
-
-DROP TABLE  IF EXISTS public.employee_table;

--- a/common/utils/migration-job/migrations/sqls/20230814020356-db-initialization-up.sql
+++ b/common/utils/migration-job/migrations/sqls/20230814020356-db-initialization-up.sql
@@ -1,4 +1,4 @@
-/* Replace with your SQL commands */
+/* Replace with your SQL CREATE commands */
 
 -- USER TABLE
 CREATE TYPE user_permission AS ENUM ('Admin', 'Employee', 'Customer', 'Vendor', 'Unauthorized');


### PR DESCRIPTION
![image](https://github.com/ferncabrera/open_ims/assets/73137447/2a3f8dd8-ea9b-4361-99e0-5244d62a5d4b)
This is the error occurring with the migration job that I noticed when skimming through the logs after noticing the tables were not being DROPped after the DO-deployment job ran.

Could not reproduce on local though....