### PR TITLE
Adjustment to migration-job yaml to avoid it from hanging indefinitely

### DIFF
--- a/.github/workflows/main_branch_acceptance_check.yaml
+++ b/.github/workflows/main_branch_acceptance_check.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Build prod images and push them (+metadata) to DockerHub with the updated tags
         run: |
           cd ${{github.workspace}}/main
-          skaffold build --cache-artifacts=false -p prod-do --file-output='${{github.workspace}}/ccg-prod-tags/production-deployment-tags.json'
+          skaffold build --cache-artifacts=false -p prod-do --tag='${{github.event.pull_request.head.sha}}' --file-output='${{github.workspace}}/ccg-prod-tags/production-deployment-tags.json'
 
       - name: Push new tags (and migrations in the future) to repository for deployment
         uses: cpina/github-action-push-to-another-repository@main

--- a/common/utils/migration-job/kustomize/base/migration-job.yaml
+++ b/common/utils/migration-job/kustomize/base/migration-job.yaml
@@ -25,5 +25,5 @@ spec:
                 name: postgres-credentials
                 key: POSTGRES_USER
       restartPolicy: Never
-
+  activeDeadlineSeconds: 100
   backoffLimit: 5

--- a/microservices/server/kustomize/base/server-deployment.yaml
+++ b/microservices/server/kustomize/base/server-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       - name: "job-wait-initcontainer"
         imagePullPolicy: Always
         image: "groundnuty/k8s-wait-for:v2.0"
-        # imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # command: ["/usr/bin/timeout", "3", "wait_for.sh"]
         args: 
         - "job-wr"
         - "migration-job"


### PR DESCRIPTION
Preventative fix for an error encountered in PROD deployment while debugging our cache, if the image fails to pull for the migration-job pods running the job (or any other error that doesn't allow for the pod to actually start) then the actual migration-job itself could hang indefinitely with the first pod unable to start and relay to the migration-job that there is an error with the deployment.

This should ensure that the job is forcefully removed (and deployment fails) if it does not successfully complete within 100 seconds which is fine (for now, although may need to be adjusted later once the migration pattern is finalized).